### PR TITLE
Allow setting of the airbrake host in settings

### DIFF
--- a/flask_airbrake.py
+++ b/flask_airbrake.py
@@ -18,8 +18,9 @@ except ImportError:
 def make_client(client_cls, app, environment=None, base_url=None):
     api_key = app.config.get('AIRBRAKE_API_KEY')
     project_id = app.config.get('AIRBRAKE_PROJECT_ID')
+    base_url = app.config.get('AIRBRAKE_HOST', None)
     return client_cls(
-        project_id, api_key, environment, base_url
+        project_id=project_id, api_key=api_key, host=base_url, timeout=None
     )
 
 


### PR DESCRIPTION
This allows exceptions to be sent to third party services that use the airbrake api spec.